### PR TITLE
Fix incorrect table headings in /admin/users

### DIFF
--- a/lib/railsbricks/assets/views/admin/users/devise_email/index.html.erb
+++ b/lib/railsbricks/assets/views/admin/users/devise_email/index.html.erb
@@ -18,9 +18,9 @@
 <table class="table table-striped">
   <tr>
     <th>User ID</th>
+    <th>Email</th>
     <th>Admin</th>
     <th>Locked</th>
-    <th>Email</th>
     <th>Sign In Count</th>
     <th>Created At</th>
     <th>Last Sign In</th>


### PR DESCRIPTION
I built a test app and noticed that some of the columns didn't match the database data.  There was a small mistake in the headings which this PR fixes.